### PR TITLE
Switch to weekly builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Build & push to GHCR
 on:
   push:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */7 * *'
 
 jobs:
   docker:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repo holds [Satellite](https://git.sr.ht/~gsthnz/satellite), a Project Gemini static file
 server software, Docker build recipe with GitHub Actions.
 
-The latest version tag is rebuilt daily at UTC 00:00 to ensure the latest dependencies / OS
+The latest version tag is rebuilt weekly to ensure the latest dependencies / OS
 versions.
 
 You can pull the latest tagged version of Satellite:


### PR DESCRIPTION
Reduces the load on GitHub Actions servers a bit by reducing the number of builds.